### PR TITLE
Fix unchanged-tup with ^c^ syntax

### DIFF
--- a/examples/unchanged-tup
+++ b/examples/unchanged-tup
@@ -1,3 +1,3 @@
-: |> sh unchanged-gen input -- %o |> source
+: |> ^o^ sh unchanged-gen input -- %o |> source
 : source |> sh unchanged-run source -- %o |> output
 


### PR DESCRIPTION
Hi Neil,

Pretty self-explanatory fix.  Tup has a ^c^ notation for when you want outputs to be diffed against old version.
