### PR TITLE
SCons examples

### DIFF
--- a/Util.hs
+++ b/Util.hs
@@ -35,7 +35,7 @@ data Opt
       deriving Show
 
 
-data Tool = Tup | Ninja | Shake | Make | Fabricate
+data Tool = Tup | Ninja | Shake | Make | Fabricate | SCons
     deriving (Show,Eq,Enum,Bounded)
 
 
@@ -119,6 +119,7 @@ run name tool opts = do
     case tool of
         Shake -> system_ $ "runhaskell -Werror -fwarn-unused-binds -fwarn-unused-imports " ++ name ++ "-shake.hs --quiet -j" ++ show p ++ " " ++ target
         Make -> system_ $ "make --file=" ++ name ++ "-make --quiet -j" ++ show p ++ " " ++ target
+        SCons -> system_ $ "scons -f " ++ name ++ "-scons -s -j" ++ show p ++ " " ++ target
         Ninja -> system_ $ "ninja -f " ++ name ++ "-ninja.ninja -j" ++ show p ++ " " ++ target ++ " > " ++ devNull
         Tup -> do
                 b <- doesDirectoryExist ".tup"

--- a/examples/basic-scons
+++ b/examples/basic-scons
@@ -1,0 +1,4 @@
+import os
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH','.')
+env.Command('output','input','sh basic-run $SOURCE -- $TARGET')

--- a/examples/include-scons
+++ b/examples/include-scons
@@ -1,0 +1,1 @@
+Object('main.o','include-main.c')

--- a/examples/monad1-scons
+++ b/examples/monad1-scons
@@ -1,0 +1,16 @@
+import os
+import SCons.Util
+
+def ConsFileDeps(env, target, source, *args, **kw):
+    if not SCons.SCons.Util.is_List(target):
+        target = [target]
+    if not SCons.SCons.Util.is_List(source):
+        source = [source]
+    env.Command(target[0],source[0],'cat $SOURCE | xargs cat > $TARGET')
+    with open(source[0],"r") as f:
+        for l in f.readlines():
+            env.Depends(target[0], l.rstrip('\n'))
+
+env = Environment(ENV = os.environ)
+env.AddMethod(ConsFileDeps, "ConsFileDeps")
+env.ConsFileDeps('output','list')

--- a/examples/monad2-scons
+++ b/examples/monad2-scons
@@ -1,0 +1,28 @@
+import os
+import SCons.Builder
+
+def scansrcs(target, source, env):
+        try:
+            f=open(str(source[0]), 'r')
+        except:
+            print "scansrcs: Can't open source list file '%s'" % str(source[0])
+            raise
+        for line in f:
+            src = line.strip()
+            try:
+                env['SCANSRCS_FUNC'](env, src, env['SCANSRCS_TARGET'])
+            except:
+                print "SCANSRCS func raised exception:"
+                raise
+        f.close()
+
+def add_target(env, source, tgt):
+        env.Depends(tgt, source)
+
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH','.')
+env.Append(BUILDERS = {'ScanSrcs' : SCons.Builder.Builder(action=scansrcs)})
+list = env.Command('list','source','sh monad2-run $SOURCE -- $TARGET')
+output = env.Command('output',list,'cat $SOURCE | xargs cat > $TARGET')
+dummy = env.ScanSrcs('#dummy-target', list, SCANSRCS_FUNC=add_target, SCANSRCS_TARGET=output)
+env.Depends(output, dummy)

--- a/examples/monad3-scons
+++ b/examples/monad3-scons
@@ -1,0 +1,36 @@
+import os
+import SCons.Builder
+
+def scansrcs(target, source, env):
+        try:
+            f=open(str(source[0]), 'r')
+        except:
+            print "scansrcs: Can't open source list file '%s'" % str(source[0])
+            raise
+        for line in f:
+            src = line.strip()
+            try:
+                if src != "gen":
+                    env['SCANSRCS_FUNC'](env, src, env['SCANSRCS_TARGET'])
+                else:
+                    env['GEN_FUNC'](env, source, env['SCANSRCS_TARGET'])
+            except:
+                raise
+        f.close()
+
+def add_target(env, source, tgt):
+        env.Depends(tgt, source)
+
+def run_gencmd(env, source, tgt):
+        gen = env.Command('gen', source, 'sh monad3-gen -- $TARGET')
+        env.Depends(tgt, gen)
+
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH','.')
+env.Append(BUILDERS = {'ScanSrcs' : SCons.Builder.Builder(action=scansrcs)})
+list = env.Command('list','source','sh monad3-run $SOURCE -- $TARGET')
+output = env.Command('output',list,'cat $SOURCE | xargs cat > $TARGET')
+dummy = env.ScanSrcs('#dummy-target', list, 
+                     SCANSRCS_FUNC=add_target, SCANSRCS_TARGET=output,
+                     GEN_FUNC=run_gencmd)
+env.Depends(output, dummy)

--- a/examples/multiple-scons
+++ b/examples/multiple-scons
@@ -1,0 +1,6 @@
+import os
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH','.')
+env.Command(['source1','source2'], 'input', 'sh multiple-gen $SOURCE -- $TARGETS')
+env.Command('output1', 'source1', 'sh multiple-run $SOURCE -- $TARGET')
+env.Command('output2', 'source2', 'sh multiple-run $SOURCE -- $TARGET')

--- a/examples/parallel-scons
+++ b/examples/parallel-scons
@@ -1,0 +1,5 @@
+import os
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH','.')
+env.Command('output1','input1','sh parallel-run $SOURCE -- $TARGET')
+env.Command('output2','input2','sh parallel-run $SOURCE -- $TARGET')

--- a/examples/spaces-scons
+++ b/examples/spaces-scons
@@ -1,0 +1,3 @@
+import os
+env = Environment(ENV = os.environ)
+env.Command('output file','input file','cp $SOURCE $TARGET')

--- a/examples/system-scons
+++ b/examples/system-scons
@@ -1,0 +1,7 @@
+import os
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH', '.')
+s = env.Command('source', [], 'sh system-gen -- $TARGET')
+env.Precious(s)
+env.AlwaysBuild(s)
+env.Command('output', s, 'sh system-run $SOURCE -- $TARGET')

--- a/examples/unchanged-scons
+++ b/examples/unchanged-scons
@@ -1,0 +1,5 @@
+import os
+env = Environment(ENV = os.environ)
+env.AppendENVPath('PATH','.')
+env.Command('output', 'source', 'sh unchanged-run $SOURCE -- $TARGET')
+env.Command('source', 'input', 'sh unchanged-gen $SOURCE -- $TARGET')

--- a/examples/wildcard-scons
+++ b/examples/wildcard-scons
@@ -1,0 +1,9 @@
+import os
+import SCons.Builder
+
+cpbuild_ = SCons.Builder.Builder(action="cp $SOURCE $TARGET",
+                                 single_src=True, src_suffix=".in", suffix=".out")
+
+env = Environment(ENV=os.environ, BUILDERS={'CpBuild' : cpbuild_})
+env.CpBuild([os.path.splitext(t)[0] for t in BUILD_TARGETS])
+


### PR DESCRIPTION
Hi,

this patch adds SCons examples to the "Shootout". All problems pass with "success" on my side (SCons 2.3.1, Python 2.7.3, Ubuntu LTS 12.04)...
There is no script for "pool", it's not really applicable since SCons knows only one "stage"...building at full throttle. ;)
Also the "monad" examples look a little wild, but it really needs a lot of trickery to force a completely different dependency handling onto SCons...only to satisfy the given test setup (one wouldn't actually model the build like this).

Best regards,

Dirk 
